### PR TITLE
feat: add Python 3.12 and 3.13 support

### DIFF
--- a/ci/cibuildwheel_linux_before_all.sh
+++ b/ci/cibuildwheel_linux_before_all.sh
@@ -6,7 +6,7 @@ PACKAGE=$1
 pip install 'conan>=2' 'cmake>=3.23' ninja
 
 # Perl dependencies required to build OpenSSL.
-yum install -y perl-IPC-Cmd perl-Digest-SHA
+yum install -y perl-IPC-Cmd perl-Digest-SHA perl-Time-Piece
 
 # Install Conan configuration.
 conan profile detect
@@ -26,4 +26,8 @@ conan export /work/libqi
 # This is because the GLIBC from the manylinux images are often older than the
 # ones that were used to build the precompiled binaries, which means the binaries
 # cannot by executed.
-conan install "$PACKAGE" --build="*" --profile:all default --profile:all cppstd17
+#
+# Use a fixed output folder so that the generated toolchain file path is
+# predictable and can be referenced by scikit-build-core.
+conan install "$PACKAGE" --build="*" --profile:all default --profile:all cppstd17 \
+    --output-folder=/conan-generators

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ classifiers=[
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
 ]
 maintainers = [
@@ -64,4 +66,4 @@ build-frontend = "build"
 before-all = ["ci/cibuildwheel_linux_before_all.sh {package}"]
 
 [tool.cibuildwheel.linux.config-settings]
-"cmake.args" = ["--preset=conan-release"]
+"cmake.args" = ["-DCMAKE_TOOLCHAIN_FILE=/conan-generators/build/release/generators/conan_toolchain.cmake", "-DCMAKE_BUILD_TYPE=Release", "-DCMAKE_PREFIX_PATH=/conan-generators/build/release/generators"]

--- a/qipython/common.hpp
+++ b/qipython/common.hpp
@@ -116,8 +116,13 @@ boost::optional<T> extractKeywordArg(pybind11::dict kwargs,
 /// finalizing or not.
 inline boost::optional<bool> interpreterIsFinalizing()
 {
-// `_Py_IsFinalizing` is only available on CPython 3.7+
-#if PY_VERSION_HEX >= 0x03070000
+// `_Py_IsFinalizing` was a private CPython API available since 3.7.
+// It was removed in Python 3.13 (replaced by the public `Py_IsFinalizing`).
+// `Py_IsFinalizing` is the public API, available since CPython 3.9,
+// but only guaranteed visible outside of Py_LIMITED_API mode from 3.13.
+#if PY_VERSION_HEX >= 0x030d0000
+  return boost::make_optional(Py_IsFinalizing() != 0);
+#elif PY_VERSION_HEX >= 0x03070000
   return boost::make_optional(_Py_IsFinalizing() != 0);
 #else
   // There is no way of knowing on older versions.


### PR DESCRIPTION
- Fix _Py_IsFinalizing removed in Python 3.13; use public Py_IsFinalizing() for Python >= 3.13 and keep _Py_IsFinalizing() for 3.7-3.12
- Add perl-Time-Piece yum dependency required to build OpenSSL 3.6.x
- Use --output-folder=/conan-generators in conan install for predictable generator paths with scikit-build-core (replaces --preset=conan-release)
- Add Python 3.12 and 3.13 classifiers to pyproject.toml

Create a release with Python 3.12 and 3.13 wheels for manylinux